### PR TITLE
PLAT-150012 - c3-nginx-ingress 4.13.9-c3.1 (controller 1.13.9 FIPS)

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: c3-nginx-ingress
 sources:
 - https://ci-artifacts.c3.ai/v1/helm
-version: 4.13.9
+version: 4.13.9-c3.1

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -13,11 +13,8 @@ keywords:
 - nginx
 kubeVersion: '>=1.21.0-0'
 maintainers:
-- name: cpanato
-- name: Gacko
-- name: strongjz
-- name: tao12345666333
-name: ingress-nginx
+- name: Kapil Kalra
+name: c3-nginx-ingress
 sources:
-- https://github.com/kubernetes/ingress-nginx
+- https://ci-artifacts.c3.ai/v1/helm
 version: 4.13.9

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.2.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.2.md
@@ -1,9 +1,0 @@
-# Changelog
-
-This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
-
-### 4.12.2
-
-* Update Ingress-Nginx version controller-v1.12.2
-
-**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.1...helm-chart-4.12.2

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.9-c3.1.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.9-c3.1.md
@@ -1,0 +1,12 @@
+# Changelog
+
+This file documents the C3-specific changes layered on top of upstream [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart 4.13.9 (controller v1.13.9). The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.9-c3.1
+
+* Export controller health port via the service (PLAT-64979)
+* Support private service connect (helm-chart-4.8.3-1)
+* Remove pinned `digest`/`digestChroot` from the controller image so the C3 registry override (`registry.c3.ai/ingress-nginx-controller-fips`) takes effect
+* Add `enableServiceLinks` support to the controller pod spec (Deployment and DaemonSet), defaulting to `false`
+
+**Upstream base**: https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.13.9

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -76,6 +76,7 @@ spec:
     {{- if .Values.controller.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.controller.shareProcessNamespace }}
     {{- end }}
+      enableServiceLinks: {{ .Values.controller.enableServiceLinks }}
       containers:
         - name: {{ .Values.controller.containerName }}
           {{- with (merge .Values.controller.image .Values.global.image) }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -82,6 +82,7 @@ spec:
     {{- if .Values.controller.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.controller.shareProcessNamespace }}
     {{- end }}
+      enableServiceLinks: {{ .Values.controller.enableServiceLinks }}
       containers:
         - name: {{ .Values.controller.containerName }}
           {{- with (merge .Values.controller.image .Values.global.image) }}

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -6,6 +6,9 @@ metadata:
   {{- range $key, $value := .Values.controller.service.annotations }}
     {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
+  {{- if .Values.controller.service.psc.enabled }}
+    {{ .Values.controller.service.psc.annotation.key }}: "{{ .Values.controller.service.psc.annotation.value }}"
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -88,6 +88,15 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
   {{- end }}
+  {{- if .Values.controller.service.exposeHealthPort }}
+    - name: health
+      port: {{ .Values.controller.service.ports.health }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.health }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+      appProtocol: https
+    {{- end }}
+  {{- end }}
   {{- range $key, $value := .Values.tcp }}
     - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
       port: {{ $key }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -31,8 +31,6 @@ controller:
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
     tag: "v1.13.9"
-    digest: sha256:d803625b20d471400fdae9dce0fdd076c0361f8f7e1ecee0dcd2f84fa0d196f8
-    digestChroot: sha256:61c2fcab0f77087f9999256139a2760fca021e038b83ff917ed34ed699af4b3b
     pullPolicy: IfNotPresent
     runAsNonRoot: true
     # -- This value must not be changed using the official image.

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -546,16 +546,19 @@ controller:
     enableHttp: true
     # -- Enable the HTTPS listener on both controller services or not.
     enableHttps: true
+    exposeHealthPort: false
     ports:
       # -- Port the external HTTP listener is published with.
       http: 80
       # -- Port the external HTTPS listener is published with.
       https: 443
+      health: 10254
     targetPorts:
       # -- Port of the ingress controller the external HTTP listener is mapped to.
       http: http
       # -- Port of the ingress controller the external HTTPS listener is mapped to.
       https: https
+      health: 10254
     # -- Declare the app protocol of the external HTTP and HTTPS listeners or not. Supersedes provider-specific annotations for declaring the backend protocol.
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
     appProtocol: true

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -485,6 +485,11 @@ controller:
   service:
     # -- Enable controller services or not. This does not influence the creation of either the admission webhook or the metrics service.
     enabled: true
+    psc:
+      enabled: false
+      annotation:
+        key: "cloud.google.com/load-balancer-type"
+        value: "Internal"
     external:
       # -- Enable the external controller service or not. Useful for internal-only deployments.
       enabled: true

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -674,6 +674,10 @@ controller:
   # shareProcessNamespace enables process namespace sharing within the pod.
   # This can be used for example to signal log rotation using `kill -USR1` from a sidecar.
   shareProcessNamespace: false
+  # -- enableServiceLinks indicates whether information about services should be injected
+  # into Pod's environment variables, matching the syntax of Docker links.
+  # Defaults to false to reduce the risk of environment variable conflicts and improve security.
+  enableServiceLinks: false
   # -- Additional containers to be added to the controller pod.
   # See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   extraContainers: []


### PR DESCRIPTION
## Summary
- Rebase C3 customizations onto upstream ingress-nginx helm-chart-4.13.9 (controller v1.13.9).
- Carries forward the existing C3 fork changes: controller health-port export (PLAT-64979), private service connect, removed pinned controller image digest, and `enableServiceLinks` support.
- Chart versioned as `4.13.9-c3.1` to distinguish from pristine upstream `4.13.9` (scheme supports `-c3.2`, `-c3.3`, ... for future rebuilds on the same upstream).
- Addresses 12 INFOSEC HIGH findings open against `ingress-nginx-controller-fips:1.12.1`.

JIRA: https://c3energy.atlassian.net/browse/PLAT-150012

## C3 commits (on top of upstream helm-chart-4.13.9)
- PLAT-64979 - export controller health port
- private service connect support
- remove ingress-nginx-controller digest (so C3 registry override applies)
- add enableServiceLinks (Deployment + DaemonSet), default false
- set chart version 4.13.9-c3.1 + changelog

## Test plan
- [x] `helm package` -> `c3-nginx-ingress-4.13.9-c3.1.tgz`
- [x] `helm template` renders cleanly
- [ ] Publish chart to OCI registry (oci://us-west1-docker.pkg.dev/cicd-360621/helm-charts)
- [ ] Bump dependency + image tag in c3server (support/v8.10)
- [ ] Deploy to aksleslie; ingress controller pods healthy
- [ ] INFOSEC rescan clears the 12 HIGH findings

Made with [Cursor](https://cursor.com)